### PR TITLE
Add Docker image and instructions on how to run as a container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+*.gem
+.git
+config/config.yml
+config/colors.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ ADD . /home/nailed/app
 RUN chown nailed:users /home/nailed/app/ -R
 USER nailed
 WORKDIR /home/nailed/app
-RUN ls -la
 # add the dependencies
 RUN bundle config build.nokogiri "--use-system-libraries"
 RUN bundle install --path /home/nailed/app/vendor/bundle
@@ -26,9 +25,7 @@ RUN bundle install --path /home/nailed/app/vendor/bundle
 RUN rm -rf config && ln -s /data/config config
 RUN rm -rf log && ln -s /data/log log
 
-# Bugzilla configuration
-#ENV DEFAULT_OSCRC_PATH /data/config/oscrc
-# Guthub configuration
+# Github and Bugzilla configuration
 ENV OCTOKIT_NETRC /data/config/netrc
 ENV HOME /data/config
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM opensuse:13.2
+MAINTAINER Duncan Mac-Vicar P. "dmacvicar@suse.de"
+
+RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+    libxml2-devel libxslt-devel \
+    sqlite3-devel gcc make ruby-devel rubygem-bundler \
+    ca-certificates ca-certificates-mozilla git-core
+
+# Database location
+ENV DATABASE_URL sqlite:///data/db/nailed.db
+
+RUN useradd -m nailed
+RUN mkdir -p /data/db && mkdir -p /data/log && mkdir -p /data/config
+RUN chown nailed:users /data/ -R
+VOLUME ["/data"]
+# add the git tree with the app
+ADD . /home/nailed/app
+RUN chown nailed:users /home/nailed/app/ -R
+USER nailed
+WORKDIR /home/nailed/app
+RUN ls -la
+# add the dependencies
+RUN bundle config build.nokogiri "--use-system-libraries"
+RUN bundle install --path /home/nailed/app/vendor/bundle
+# redirect the config to the volume
+RUN rm -rf config && ln -s /data/config config
+RUN rm -rf log && ln -s /data/log log
+
+# Bugzilla configuration
+#ENV DEFAULT_OSCRC_PATH /data/config/oscrc
+# Guthub configuration
+ENV OCTOKIT_NETRC /data/config/netrc
+ENV HOME /data/config
+
+EXPOSE 4567
+CMD ["--help"]
+ENTRYPOINT ["bundle", "exec", "bin/nailed"]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,41 @@ nailed --jenkins
 * create a `cronjob` for automated data collection with `nailed`
 * start the webserver with `nailed --server`
 
+## Running as a Docker container
+
+* Build the image
+
+```
+$ git clone https://github.com/MaximilianMeister/nailed
+$ cd nailed
+$ docker build -t nailed:latest .
+```
+
+* Create a directory to hold the data, and create the config, db and log subdirectories
+
+```
+mkdir -p /mystorage/config
+mkdir -p /mystorage/log
+mkdir -p /mystorage/db
+``
+
+Add .oscrc and netrc into /mystorage/config.
+You need to mount that directory as the /data volume in the container
+
+* Migrate and fetch initial data
+
+```
+docker run -ti -v /mystorage:/data nailed:latest --migrate
+```
+
+* Run the server
+
+In this case, we map it to port 8000 on the host
+
+```
+docker run -ti -v /mystorage:/data -p 8000:4567 nailed:latest --server
+```
+
 ## Credits
 
 * [Duncan Mac-Vicar P.](https://github.com/dmacvicar) for the awesome [Bicho](https://github.com/dmacvicar/bicho) gem.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ mkdir -p /mystorage/log
 mkdir -p /mystorage/db
 ```
 
-Add .oscrc and netrc into /mystorage/config.
-You need to mount that directory as the /data volume in the container
+Add .oscrc and netrc and config.yml into /mystorage/config. You can as well add colors.yml
+here and override some defaults.
+You need to mount that directory as the /data volume in the container.
 
 * Migrate and fetch initial data
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ docker build -t nailed:latest .
 mkdir -p /mystorage/config
 mkdir -p /mystorage/log
 mkdir -p /mystorage/db
-``
+```
 
 Add .oscrc and netrc into /mystorage/config.
 You need to mount that directory as the /data volume in the container


### PR DESCRIPTION
The following Dockerfile and instructions allow to run nailed as a Docker container. The included image is based on openSUSE 13.2 and setups everything the README specifies.

The data, log and config is kept in a data volume that can be injected when running it.