### PR TITLE
Track closed PRs and extra info for all PRs

### DIFF
--- a/bin/app
+++ b/bin/app
@@ -361,7 +361,7 @@ class App < Sinatra::Base
   #
   get "/json/github/donut/allpulls" do
     pulltop = []
-    allpulls = Pullrequest.aggregate(:repository_organization_oname, :repository_rname, :all.count)
+    allpulls = Pullrequest.all(state: "open").aggregate(:repository_organization_oname, :repository_rname, :all.count)
     allpulls.each do |donut_bite|
       pulltop << { label: "#{donut_bite[0]}/#{donut_bite[1]}", value: donut_bite[2] }
     end
@@ -378,13 +378,14 @@ class App < Sinatra::Base
   end
 
   # all open pull requests for repo
-  github_repos = Pullrequest.all(order: [:created_at.desc]).map do |row|
+  github_repos = Pullrequest.all(state: "open", order: [:created_at.desc]).map do |row|
     [row.repository_organization_oname, row.repository_rname]
   end.uniq
 
   github_repos.each do |repo|
     get "/json/github/#{repo[0]}/#{repo[1]}/open" do
       Pullrequest.all(
+        state:                         "open",
         repository_rname:              repo[1],
         repository_organization_oname: repo[0]).to_json
     end

--- a/bin/nailed
+++ b/bin/nailed
@@ -63,7 +63,7 @@ opts.each_pair do |key, val|
     if val
       github_client = Nailed::Github.new
       github_client.update_pull_states
-      github_client.get_open_pulls
+      github_client.get_pull_requests
       github_client.write_allpull_trends
     end
   when :jenkins

--- a/db/database.rb
+++ b/db/database.rb
@@ -81,6 +81,9 @@ class Pullrequest
   property :state, String
   property :url, String
   property :created_at, DateTime
+  property :updated_at, DateTime
+  property :closed_at, DateTime
+  property :merged_at, DateTime
 
   belongs_to :repository
 end
@@ -90,6 +93,7 @@ class Pulltrend
   property :id, Serial, key: true
   property :time, String
   property :open, Integer
+  property :closed, Integer
 
   belongs_to :repository
 end
@@ -99,6 +103,7 @@ class AllpullTrend
   property :id, Serial, key: true
   property :time, String
   property :open, Integer
+  property :closed, Integer
 end
 
 # TODO: Jenkins specific tables


### PR DESCRIPTION
As having only open PR store does not paint the whole
picture, this stores the closed PR as well as all the
different times of importance(updated_at, closed_at,
merged_at) for future use.

 - renames the get_open_pulls method to get_pull_requests
 - allows to modify the state of the PRs to get, defaults to all
 - 2 new fields on teh database for tracking the number of closed PRs
 - only updates the open pull requests to avoid excessive api calls
 - when a PR changes from open to close, update it on the db instead of deleting it
 - store the total closed PR per repo and the total closed PR for all repos
 - store all the different times that the api provides