### PR TITLE
Updates the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Note that this is always a bit outdated.
 You can use nailed directly from a git checkout as well. Make sure to fetch the dependencies and call `nailed` from the `bin` directory.
 ### SUSE
 ```
-zypper in libxml2-devel sqlite3-devel gcc make ruby-devel
+zypper in libxml2-devel libxslt-devel sqlite3-devel gcc make ruby-devel \
+          ruby2.2-rubygem-bundler ruby2.2-devel
 bundle install
 ```
 


### PR DESCRIPTION
The dependencies ruby2.2-rubygem-bundler, ruby2.2-devel and libxslt-devel
are necessary for the installation using git.

Signed-off-by: Jürgen Löhel <jloehel@suse.com>