### PR TITLE
Updates the version of bicho to 0.0.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER Maximilian Meister "mmeister@suse.de"
 
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
     libxml2-devel libxslt-devel \
-    sqlite3-devel gcc make ruby-devel ruby2.2-rubygem-bundler \
+    sqlite3-devel gcc make ruby-devel ruby2.3-rubygem-bundler \
     ca-certificates ca-certificates-mozilla git-core \
-    ruby2.2-devel
+    ruby2.3-devel
 
 RUN mkdir -p /nailed/data/config
 VOLUME /nailed/data
@@ -14,8 +14,8 @@ VOLUME /nailed/data
 ADD . /nailed
 WORKDIR /nailed
 
-# set Ruby 2.2 as the default version
-RUN ln -sf /usr/bin/ruby.ruby2.2 /usr/local/bin/ruby
+# set Ruby 2.3 as the default version
+RUN ln -sf /usr/bin/ruby.ruby2.3 /usr/local/bin/ruby
 
 # add the dependencies
 RUN bundle config build.nokogiri "--use-system-libraries"

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
 source "https://rubygems.org"
 
 # back-end
-gem "trollop", "2.0"
-gem "bicho", "0.0.13"
+gem "trollop", "2.1.2"
+gem "bicho", "0.0.16"
 gem "octokit", "3.7.0"
 gem "data_mapper", "1.2.0"
 gem "dm-sqlite-adapter", "1.2.0"
-gem "netrc", "0.10.2"
-gem "jenkins_api_client", "1.3.0"
+gem "netrc", "0.11.0"
+gem "jenkins_api_client", "1.5.3"
 # front-end
 gem "sinatra-base", "1.4.0"
 gem "sinatra-assetpack", "0.3.3"

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ You can use nailed directly from a git checkout as well. Make sure to fetch the 
 ### SUSE
 ```
 zypper in libxml2-devel libxslt-devel sqlite3-devel gcc make ruby-devel \
-          ruby2.2-rubygem-bundler ruby2.2-devel
-bundle install
+          ruby2.3-rubygem-bundler ruby2.3-devel
+
+bundle.ruby2.3 install
 ```
 
 * for the SUSE BugZilla API make sure you have an `.oscrc` file with your credentials in ~


### PR DESCRIPTION
It's also necessary to bump ruby to ruby2.3 because bicho
requires ruby '>= 2.3' since version 0.0.16.

Signed-off-by: Jürgen Löhel <jloehel@suse.com>