### PR TITLE
Adds an additional table for every product with all qe_top_5 bugs.

### DIFF
--- a/bin/app
+++ b/bin/app
@@ -284,11 +284,6 @@ class App < Sinatra::Base
     Bugreport.all(is_open: true).to_json
   end
 
-  #allqe_top_5
-  get "/json/bugzilla/qe_top_5" do
-    Bugreport.all(:is_open => true, :whiteboard.like => "%qe_top_5%").to_json
-  end
-
   # allopenwithoutl3
   get "/json/bugzilla/allopenwithoutl3" do
     (Bugreport.all(is_open: true) - Bugreport.all(:whiteboard.like => "%openL3%", :is_open => true)).to_json
@@ -301,12 +296,14 @@ class App < Sinatra::Base
 
   # product -> qe_top_5
   Nailed::Config.products.each do |_product, values|
-    versions = values["versions"]
-    versions.each do |version|
-      get "/json/bugzilla/#{version.tr(" ", "_")}/qe_top_5" do
-        (Bugreport.all(:is_open => true, :product_name => version, whiteboard.like => "%qe_top_5%")).to_json
-      end
-    end unless versions.nil?
+    if values["qe"]
+      versions = values["versions"]
+      versions.each do |version|
+        get "/json/bugzilla/#{version.tr(" ", "_")}/qe_top_5" do
+          (Bugreport.all(:is_open => true, :product_name => version, :whiteboard.like => "%qe_top_5%")).to_json
+        end
+      end unless versions.nil?
+    end
   end
 
   # product -> openwithoutl3
@@ -426,6 +423,7 @@ class App < Sinatra::Base
 
         @product = version
         @product_ = version.tr(" ", "_")
+        @top5 = values["qe"]
 
         haml :bugzilla
       end

--- a/bin/app
+++ b/bin/app
@@ -284,6 +284,11 @@ class App < Sinatra::Base
     Bugreport.all(is_open: true).to_json
   end
 
+  #allqe_top_5
+  get "/json/bugzilla/qe_top_5" do
+    Bugreport.all(:is_open => true, :whiteboard.like => "%qe_top_5%").to_json
+  end
+
   # allopenwithoutl3
   get "/json/bugzilla/allopenwithoutl3" do
     (Bugreport.all(is_open: true) - Bugreport.all(:whiteboard.like => "%openL3%", :is_open => true)).to_json
@@ -292,6 +297,16 @@ class App < Sinatra::Base
   # allopenl3
   get "/json/bugzilla/allopenl3" do
     Bugreport.all(:is_open => true, :whiteboard.like => "%openL3%").to_json
+  end
+
+  # product -> qe_top_5
+  Nailed::Config.products.each do |_product, values|
+    versions = values["versions"]
+    versions.each do |version|
+      get "/json/bugzilla/#{version.tr(" ", "_")}/qe_top_5" do
+        (Bugreport.all(:is_open => true, :product_name => version, whiteboard.like => "%qe_top_5%")).to_json
+      end
+    end unless versions.nil?
   end
 
   # product -> openwithoutl3

--- a/config/config.yml
+++ b/config/config.yml
@@ -21,6 +21,7 @@ products:
     versions:
     # Array of Bugzilla products (typically different versions of one product)
     # Exact names have to be given, as they appear in Bugzilla (can not be arbitrary)
+    qe: # true, false; Show most important Quality Engineering bugs for this product.
     organization: # here goes the organization name (under which your repos are hosted) as it appears in GitHub
     repos:
     # Array of GitHub repository names, as they appear in GitHub

--- a/views/bugzilla.haml
+++ b/views/bugzilla.haml
@@ -18,6 +18,24 @@
         #top_components
     .row.no-hide
       .col-md-12
+        %h5 Quality Engineering top 5
+        %hr
+        %table{:data => {:toggle => "table", :url => "/json/bugzilla/#{@product_}/qe_top_5", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
+          %thead
+            %tr
+              %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
+                Bug Id
+              %th{:data => {:field => "summary", :sortable => "true", :class => "summary"}}
+                Summary
+              %th{:data => {:field => "priority", :sortable => "true", :formatter => "bugzillaPriority"}}
+                Priority
+              %th{:data => {:field => "component", :sortable => "true"}}
+                Component
+              %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
+                Creation Time
+              %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
+                Last Change Time
+      .col-md-12
         %h5 L3 Bugs
         %hr
         %table{:data => {:toggle => "table", :url => "/json/bugzilla/#{@product_}/openl3", :search => "true", :show => {:refresh => "true", :columns => "true"}}}

--- a/views/bugzilla.haml
+++ b/views/bugzilla.haml
@@ -17,24 +17,25 @@
         %h5 Top 5 Components
         #top_components
     .row.no-hide
-      .col-md-12
-        %h5 Quality Engineering top 5
-        %hr
-        %table{:data => {:toggle => "table", :url => "/json/bugzilla/#{@product_}/qe_top_5", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
-          %thead
-            %tr
-              %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
-                Bug Id
-              %th{:data => {:field => "summary", :sortable => "true", :class => "summary"}}
-                Summary
-              %th{:data => {:field => "priority", :sortable => "true", :formatter => "bugzillaPriority"}}
-                Priority
-              %th{:data => {:field => "component", :sortable => "true"}}
-                Component
-              %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
-                Creation Time
-              %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
-                Last Change Time
+      - if @top5
+        .col-md-12
+          %h5 Quality Engineering top 5
+          %hr
+          %table{:data => {:toggle => "table", :url => "/json/bugzilla/#{@product_}/qe_top_5", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
+            %thead
+              %tr
+                %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
+                  Bug Id
+                %th{:data => {:field => "summary", :sortable => "true", :class => "summary"}}
+                  Summary
+                %th{:data => {:field => "priority", :sortable => "true", :formatter => "bugzillaPriority"}}
+                  Priority
+                %th{:data => {:field => "component", :sortable => "true"}}
+                  Component
+                %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
+                  Creation Time
+                %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
+                  Last Change Time
       .col-md-12
         %h5 L3 Bugs
         %hr


### PR DESCRIPTION
Can we please add an additional table for all the qe_top_5 bugs?

Signed-off-by: Jürgen Löhel <jloehel@suse.com>